### PR TITLE
[QPE-164] babel preset env polyfill added to enable printing

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "chrome": "47"
+      }
+    }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-inline-css": "2.1.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.1.0",
     "autoprefixer": "6.3.7",
     "autoprefixer-loader": "3.2.0",
     "babel": "5.8.38",

--- a/server.config.json
+++ b/server.config.json
@@ -1,5 +1,5 @@
 {
   "devServerPort": "8080",
-  "buildFolder": "./build",
+  "buildFolder": "C:\\Users\\Ahmed\\Documents\\Qlik\\Sense\\Extensions\\KPI",
   "url": "http://localhost:4848/sense/app/C%3A%5CUsers%5Cnerush%5CDocuments%5CQlik%5CSense%5CApps%5CSimpleKPIDemo/sheet/KrAeKZs/state/edit"
 }

--- a/server.config.json
+++ b/server.config.json
@@ -1,5 +1,5 @@
 {
   "devServerPort": "8080",
-  "buildFolder": "C:\\Users\\Ahmed\\Documents\\Qlik\\Sense\\Extensions\\KPI",
+  "buildFolder": "./build",
   "url": "http://localhost:4848/sense/app/C%3A%5CUsers%5Cnerush%5CDocuments%5CQlik%5CSense%5CApps%5CSimpleKPIDemo/sheet/KrAeKZs/state/edit"
 }


### PR DESCRIPTION
.browserslistrc file specify what version of chrome should the pollyfill target 

Jira ticket link
https://tretton37.atlassian.net/secure/RapidBoard.jspa?rapidView=33&projectKey=QPE&modal=detail&selectedIssue=QPE-164