### PR TITLE
[QPE-336] Icons are off

### DIFF
--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -9,9 +9,6 @@
   text-transform: none;
 }
 
-* {
-  box-sizing: border-box;
-}
 .qv-object-qsstatistic {
   width: 100%;
   height: 100%;
@@ -24,6 +21,10 @@
   @import "../semantic/src/definitions/elements/icon.less";
   @import "../semantic/src/definitions/views/statistic.less";
   @import "../semantic/src/definitions/elements/segment.less";
+
+  * {
+    box-sizing: border-box;
+  }
 
   .top-aligned-items {
     height: 100%;


### PR DESCRIPTION
The issue was caused by one of our CSS rules being too global and affecting elements outside the extension.