### PR TITLE
[QPE-271] Limit infographic icons to 10 per card/segment

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,4 +1,8 @@
 # Limitations
+## Infographic mode
+Infographic mode will max out at 10 icons, an expression will need to be set accordingly for infographic visualization to be useful.
+
+## Theme colors
 There is a known limitation with automatic color changes when changing app theme.
 
 **Expected**: The expected behaviour is for the colors in the extension to automatically be updated to the default colors of a theme when changing between themes.
@@ -6,7 +10,7 @@ There is a known limitation with automatic color changes when changing app theme
 **Actual**: The colors will change in the property panel, but the changes are not reflected in the extension object.
 
 
-## Example
+### Example
 
 **With classic theme**
 ![Example](../resources/before_changing_theme.png)

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -30,6 +30,10 @@
     box-sizing: border-box;
   }
 
+  .infographic-icon-set-wrapper {
+    line-height: 0; // hack to offset height from 4rem font-size from semantic-ui
+  }
+
   .top-aligned-items {
     height: 100%;
     display: flex;

--- a/src/statisticItem.js
+++ b/src/statisticItem.js
@@ -7,6 +7,14 @@ class Icon extends Component {
   constructor(props) {
     super(props);
   }
+  shouldComponentUpdate (nextProps) {
+    const hasValueChanged = this.props.value !== nextProps.value;
+    const hasIconChanged = this.props.valueIcon !== nextProps.valueIcon;
+    const hasIconSizeChanged = this.props.iconSize !== nextProps.iconSize;
+    const hasInfographicChanged = this.props.infographic !== nextProps.infographic;
+    const hasIsOnValueChanged = this.props.isOnValue !== nextProps.isOnValue;
+    return hasValueChanged || hasIconChanged || hasIconSizeChanged || hasInfographicChanged || hasIsOnValueChanged;
+  }
   render() {
     let {
       value,
@@ -15,18 +23,24 @@ class Icon extends Component {
       infographic,
       isOnValue
     } = this.props;
-    if(infographic) {
+    if(infographic && valueIcon) {
       let icons = [];
       if(!isNaN(value) && isFinite(value)) {
-        value = Math.min(1000, value);
-        for (let i = 0; i < value; ++i)
-          icons.push(<div className={`value--icon--wrapper ${iconSize}${isOnValue ? ` on-value` : ``} infographic`}> <i key={i} className={`${valueIcon} ${iconSize}`}></i> </div>);
+        const threshold = 10;
+        value = Math.min(threshold, value);
+        for (let i = 1; i <= value; ++i) {
+          icons.push(
+            <div key={i} className={`value--icon--wrapper ${iconSize}${isOnValue ? ` on-value` : ``} infographic`}>
+              <i key={i} className={`${valueIcon} ${iconSize}`}></i>
+            </div>
+          );
+        }
       }
 
       return (
-        <span>
+        <div className="infographic-icon-set-wrapper">
           {icons}
-        </span>
+        </div>
       );
     }
     else
@@ -49,8 +63,7 @@ export default class StatisticItem extends Component {
   }
 
   checkRequiredSize(){
-    //let embeddedItem = this.props.item.embeddedItem;
-    if(!this.props.onNeedResize) // || (embeddedItem && embeddedItem.trim().length > 0)
+    if(!this.props.onNeedResize)
       return;
 
     const { hideValue } = this.props.item;
@@ -61,7 +74,6 @@ export default class StatisticItem extends Component {
     if(valueElement && valueElement.firstChild) {
       let valueChild = valueElement.firstChild;
       let childWidth = $(valueChild).width();
-      //let childHeight = $(valueChild).height();
       if(childWidth > valueElement.clientWidth) {
         this.props.onNeedResize(true);
       } else
@@ -70,7 +82,6 @@ export default class StatisticItem extends Component {
   }
 
   render(){
-    //let size = this.props.item.size || "";
     const index = this.props.index;
     const services = this.props.services;
     const {
@@ -99,8 +110,6 @@ export default class StatisticItem extends Component {
 
     let labelStyles = { padding: "0px 5px", textAlign: textAlignment };
     let valueStyles = { padding: "0px 5px", textAlign: textAlignment };
-    // if(embeddedItem && hideLabel)
-    //  valueStyles.marginTop = `${QLIK_COMP_TOOLBAR_HEIGHT}px`;
 
     if(labelColor)
       labelStyles.color = labelColor.color;
@@ -140,15 +149,15 @@ export default class StatisticItem extends Component {
       measureIndex,
       embeddedItem,
       mainContainerElement,
-      valueStyles,
       services,
       kpisRows,
       isShow
     };
+    const icon = <Icon isOnValue={true} valueIcon={valueIcon} iconSize={iconSize} value={numericValue} infographic={infographic} />
     let valueComponent = hideValue ? null : (
       <ValueComponent {...valueComponentProps}>
-        {iconOrderFirst && this.props.item.iconPosition === 'value' ? <Icon isOnValue={true} valueIcon={valueIcon} iconSize={iconSize} value={numericValue} infographic={infographic} /> : null}
-        {value /*!infographic ? value : null*/}
+        {iconOrderFirst && this.props.item.iconPosition === 'value' ? icon : null}
+        <span style={valueStyles}>{value}</span>
         {!iconOrderFirst && this.props.item.iconPosition === 'value' ? <Icon isOnValue={true} valueIcon={valueIcon} iconSize={iconSize} value={numericValue} infographic={infographic} /> : null}
       </ValueComponent>
     );


### PR DESCRIPTION
- Limit set to infographic to avoid performance issues
- Weird spacing for infographic alongside value
- Workaround for worst performance issues with icon rendering (offsetting the fact that extension renders up to 12 times), icons will only be rendered once in that cycle.