### PR TITLE
No console errors when there are no dimensions

### DIFF
--- a/src/dimensionEntry.js
+++ b/src/dimensionEntry.js
@@ -15,6 +15,7 @@ class DimensionEntry extends Component {
 
     this.handleClick = this.handleClick.bind(this);
     this.hidePointerCursor = this.hidePointerCursor.bind(this);
+    this.getlabelWidth = this.getlabelWidth.bind(this);
 
   }
 
@@ -26,7 +27,12 @@ class DimensionEntry extends Component {
       return "default";
     }
   }
+  getlabelWidth(){
+    var chartBody = this.refs.chartBody;
+    var chartBodywidth = chartBody && chartBody.getBoundingClientRect().width;
+    return chartBodywidth;
 
+  }
   updateFlexBasis (key) {
     this.props.style.flexBasis = dividedByObject[key];
   }
@@ -70,11 +76,11 @@ class DimensionEntry extends Component {
             <a
               className={`ui ${label.size} ${label.orientation} ${label.alignment} label`}
               onClick={this.handleClick}
-              style={{ cursor: this.hidePointerCursor() }}
+              style={{ cursor: this.hidePointerCursor(), width :this.getlabelWidth() }}
             >{label.text}</a>
           )
         }
-        <div className={`ui ${divideBy} ${label.alignment} statistics`}>
+        <div className={`ui ${divideBy} ${label.alignment} statistics`} ref='chartBody'>
           {children}
         </div>
       </div>

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -67,41 +67,17 @@
   .ui.statistics, .ui.segments  {
     width: 100%;
   }
-  .ui.cards{
-    .ui.statistics{
-      display: flex;
-      text-align: center;
-      width: fit-content;
-      justify-content: center;
-    }
 
+  .ui.segments {
+    min-width: max-content;
   }
-  .ui.vertical.segments,
-  .ui.horizontal.segments {
-    height: 100%;
-  }
-
-  @media (max-width: 767px) {
-    .ui.cards {
-      height: 100%;
-    }
-  }
-
+  
   .ui.statistics .statistic > .label,
   .ui.statistic > .label {
     text-transform: none;
   }
   .ui.statistic > .value {
     width: 100%;
-  }
-  .ui.cards{
-    .statistic{
-      width: 100%;
-      text-align: center;
-      text-align: -webkit-center;
-      text-align: -ms-center;
-    }
-
   }
   .ui.segment > .label[class*="center aligned"] {
     text-align: center;
@@ -137,8 +113,20 @@
     box-sizing: border-box;
     padding: 5px 5px;
   }
+  
+  .ui.vertical.segments,
+  .ui.horizontal.segments {
+    height: 100%;
+  }
 
+  .ui.cards, .ui.segments{
+    &.edit-mode{
+      overflow: hidden;
+    }
+  }
+  
   .ui.cards {
+    align-items: center;
     margin: 0 !important;
     align-items: center;
     justify-content: space-evenly;
@@ -147,15 +135,19 @@
     display: flex;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
-  }
-  .ui.cards, .ui.segments{
-    min-width: max-content;
-    &.edit-mode{
-      overflow: hidden;
+
+    &.one > .card {
+      margin: .5rem .75rem;
+    }
+
+    @media (max-width: 767px) {
+        height: 100%;
     }
   }
+
   .ui.cards > .card,
   .ui.card {
+    align-items: center;
     padding: 0 10px;
     -ms-flex: 1;
     flex: 1;
@@ -163,7 +155,32 @@
     background-color: transparent !important;
     -ms-flex-preferred-size: 20%;
     min-width: 150px;
+    border: none;
+    box-shadow: none;
 
+    &:first-child > .statistics,
+    > .statistics {
+      border: 1px solid rgba(34,36,38,.15) !important;
+      border-radius: .28571429rem;
+      box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
+
+      @media (max-width: 767px) {
+        margin: auto;
+        padding: 1em 0;
+      }
+    }
+
+    .statistics {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      text-align: center;
+      width: 250px;
+
+      > .statistic {
+        align-items: center
+      }
+    }
   }
 
   .ui.tag.label {
@@ -213,16 +230,7 @@
     margin: 0;
     vertical-align: top;
   }
-  .ui.card{
-    max-width: max-content !important;
 
-    .ui.statistics{
-      display: flex;
-      width: fit-content;
-      display: flex;
-      justify-content: center;
-    }
-  }
   .ui.segments, .ui.cards {
     .ui.segment{
       .ui.statistics{
@@ -284,7 +292,6 @@
         text-align: right;
       }
       .top.left {
-
         border-top: none;
         border-bottom: 1px solid #a6a6a6;
         text-align: left;

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -60,9 +60,21 @@
     display: flex;
     align-items: stretch;
   }
-
-  .ui.statistics, .ui.cards, .ui.segments  {
+  .ui.stackable.cards{
     width: 100%;
+
+  }
+  .ui.statistics, .ui.segments  {
+    width: 100%;
+  }
+  .ui.cards{
+    .ui.statistics{
+      display: flex;
+      text-align: center;
+      width: fit-content;
+      justify-content: center;
+    }
+
   }
   .ui.vertical.segments,
   .ui.horizontal.segments {
@@ -82,7 +94,15 @@
   .ui.statistic > .value {
     width: 100%;
   }
+  .ui.cards{
+    .statistic{
+      width: 100%;
+      text-align: center;
+      text-align: -webkit-center;
+      text-align: -ms-center;
+    }
 
+  }
   .ui.segment > .label[class*="center aligned"] {
     text-align: center;
   }
@@ -121,7 +141,7 @@
   .ui.cards {
     margin: 0 !important;
     align-items: center;
-    justify-content: center;
+    justify-content: space-evenly;
     height: 100%;
     display: -ms-flexbox;
     display: flex;
@@ -193,20 +213,22 @@
     margin: 0;
     vertical-align: top;
   }
+  .ui.card{
+    max-width: max-content !important;
 
+    .ui.statistics{
+      display: flex;
+      width: fit-content;
+      display: flex;
+      justify-content: center;
+    }
+  }
   .ui.segments, .ui.cards {
-    overflow: auto;
     .ui.segment{
       .ui.statistics{
         display: block;
       }
     }
-    .ui.card{
-      .ui.statistics{
-        display: flex;
-      }
-    }
-
     .ui.segment, .ui.card {
       flex-direction: column;
       min-width: 150px;

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -71,7 +71,7 @@
   .ui.segments {
     min-width: max-content;
   }
-  
+
   .ui.statistics .statistic > .label,
   .ui.statistic > .label {
     text-transform: none;
@@ -113,7 +113,7 @@
     box-sizing: border-box;
     padding: 5px 5px;
   }
-  
+
   .ui.vertical.segments,
   .ui.horizontal.segments {
     height: 100%;
@@ -124,7 +124,7 @@
       overflow: hidden;
     }
   }
-  
+
   .ui.cards {
     align-items: center;
     margin: 0 !important;
@@ -230,7 +230,10 @@
     margin: 0;
     vertical-align: top;
   }
-
+  .ui.card .ui.label{
+    border: 1px solid #a6a6a6 !important;
+    border-bottom: none;
+  }
   .ui.segments, .ui.cards {
     .ui.segment{
       .ui.statistics{
@@ -251,7 +254,7 @@
         display: block;
         padding: 10px 5px;
         border-bottom: solid 1px rgb(166,166,166) !important;
-        box-sizing: content-box;
+        box-sizing: border-box;
       }
 
       >.statistics {

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -115,84 +115,87 @@ class StatisticBlock extends Component {
       kpis: this.props.kpis
     };
     if (this.props.kpis.qDimensionInfo.length > 0) {
-      if (getIfWeShouldUpdateSize(updateSizeArguments)){
+      if (this.getIfWeShouldUpdateSize(updateSizeArguments)){
         this.decreaseSize(currentSize);
       }
     } else {
-      if (getIfWeShouldUpdateSizeWithoutDimension(updateSizeArguments)) {
+      if (this.getIfWeShouldUpdateSizeWithoutDimension(updateSizeArguments)) {
         this.decreaseSize(currentSize);
       }
     }
+  }
 
-    function getIfWeShouldUpdateSize ({ containerElement, options, kpis }) {
-      const containerSize = containerElement.getBoundingClientRect();
-      let elementClientWidth = containerSize.width;
-      let elementClientHeight = containerSize.height;
-      let childrenElements = containerElement.children;
-      let dividedBy = options.divideBy;
-      let dividedByNumber = getDivideByNumber(dividedBy);
-      let childrenHeight = 0;
-      let childrenCombinedWidth = 0;
+  getIfWeShouldUpdateSize ({ containerElement, options, kpis }) {
+    const containerSize = containerElement.getBoundingClientRect();
+    let elementClientWidth = containerSize.width;
+    let elementClientHeight = containerSize.height;
+    let childrenElements = containerElement.children;
+    let dividedBy = options.divideBy;
+    let dividedByNumber = getDivideByNumber(dividedBy);
+    let childrenHeight = 0;
+    let childrenCombinedWidth = 0;
 
-      if (options.dimShowAs == "segment" && options.dimensionsOrientation == "vertical"){
-        childrenCombinedWidth = childrenElements[0].getBoundingClientRect().width;
-        for (let i = 0 ; i < childrenElements.length ; i++){
-          childrenHeight = childrenHeight + childrenElements[i].getBoundingClientRect().height;
+    if (options.dimShowAs == "segment" && options.dimensionsOrientation == "vertical"){
+      childrenCombinedWidth = childrenElements[0].getBoundingClientRect().width;
+      for (let i = 0 ; i < childrenElements.length ; i++){
+        const plusHeight = childrenElements[i] ? childrenElements[i].getBoundingClientRect().height : 0;
+        childrenHeight = childrenHeight + plusHeight;
+      }
+    }else{
+      if (dividedBy == "auto" || dividedBy == ""){
+        for (let e of childrenElements) {
+          childrenCombinedWidth = childrenCombinedWidth + e.getBoundingClientRect().width;
         }
+
       }else{
-        if (dividedBy == "auto" || dividedBy == ""){
-          for (let e of childrenElements) {
-            childrenCombinedWidth = childrenCombinedWidth + e.getBoundingClientRect().width;
-          }
-        }else{
-          let rows = kpis.qMeasureInfo.length;
-          let ratio = Math.floor(rows / dividedByNumber) + 1;
-          if (rows % dividedByNumber == 0){
-            for (let i = 0 ; i < rows/dividedByNumber ; i++ + ratio){
-              childrenHeight = childrenHeight + childrenElements[i].getBoundingClientRect().height;
-            }
-          }
-          else{
-            for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
-              childrenHeight = childrenHeight + childrenElements[i].getBoundingClientRect().height;
-            }
-          }
-          for ( let i = 0 ; i < dividedByNumber ; i++){
-            childrenCombinedWidth = childrenCombinedWidth + childrenElements[i].getBoundingClientRect().width;
+        let rows = kpis.qMeasureInfo.length;
+        let ratio = Math.floor(rows / dividedByNumber) + 1;
+        if (rows % dividedByNumber == 0){
+          for (let i = 0 ; i < rows/dividedByNumber ; i++ + ratio){
+            const plusHeight = childrenElements[i] ? childrenElements[i].getBoundingClientRect().height : 0;
+            childrenHeight = childrenHeight + plusHeight;
           }
         }
+        else{
+          for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
+            childrenHeight = childrenHeight + childrenElements[i].getBoundingClientRect().height;
+          }
+        }
+        for ( let i = 0 ; i < dividedByNumber ; i++){
+          childrenCombinedWidth = childrenCombinedWidth + childrenElements[i].getBoundingClientRect().width;
+        }
       }
-
-      return elementClientWidth < childrenCombinedWidth || elementClientHeight < childrenHeight;
     }
 
-    function getIfWeShouldUpdateSizeWithoutDimension({ containerElement, options, kpis }) {
-      const containerElementSize = containerElement.getBoundingClientRect();
-      let elementClientWidth = containerElementSize.width;
-      let elementClientHeight = containerElementSize.height;
-      let childrenElm = containerElement.children;
-      let childrenCombinedWidth = 0;
-      let childrenHeight = 0;
-      let dividedBy = options.divideBy;
-      let dividedByNumber = getDivideByNumber(dividedBy);
-      let rows = kpis.qMeasureInfo.length;
-      let ratio = Math.floor(rows / dividedByNumber) + 1;
-      if (rows % dividedByNumber == 0){
-        for (let i = 0 ; i < rows/dividedByNumber ; i++ + ratio){
-          childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
-        }
-      }
-      else{
-        for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
-          childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
-        }
-      }
-      for ( let i = 0 ; i < dividedByNumber ; i++){
-        childrenCombinedWidth = childrenCombinedWidth + childrenElm[i].getBoundingClientRect().width;
-      }
+    return elementClientWidth < childrenCombinedWidth || elementClientHeight < childrenHeight;
+  }
 
-      return elementClientWidth < childrenCombinedWidth || elementClientHeight < childrenHeight;
+  getIfWeShouldUpdateSizeWithoutDimension({ containerElement, options, kpis }) {
+    const containerElementSize = containerElement.getBoundingClientRect();
+    let elementClientWidth = containerElementSize.width;
+    let elementClientHeight = containerElementSize.height;
+    let childrenElm = containerElement.children;
+    let childrenCombinedWidth = 0;
+    let childrenHeight = 0;
+    let dividedBy = options.divideBy;
+    let dividedByNumber = getDivideByNumber(dividedBy);
+    let rows = kpis.qMeasureInfo.length;
+    let ratio = Math.floor(rows / dividedByNumber) + 1;
+    if (rows % dividedByNumber == 0){
+      for (let i = 0 ; i < rows/dividedByNumber ; i++ + ratio){
+        childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
+      }
     }
+    else{
+      for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
+        childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
+      }
+    }
+    for ( let i = 0 ; i < dividedByNumber ; i++){
+      childrenCombinedWidth = childrenCombinedWidth + childrenElm[i].getBoundingClientRect().width;
+    }
+
+    return elementClientWidth < childrenCombinedWidth || elementClientHeight < childrenHeight;
   }
   
   decreaseSize (size) {

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -126,6 +126,9 @@ class StatisticBlock extends Component {
   }
 
   getIfWeShouldUpdateSize ({ containerElement, options, kpis }) {
+    if (!containerElement || ! options || !kpis) {
+      return false;
+    }
     const containerSize = containerElement.getBoundingClientRect();
     let elementClientWidth = containerSize.width;
     let elementClientHeight = containerSize.height;
@@ -171,6 +174,9 @@ class StatisticBlock extends Component {
   }
 
   getIfWeShouldUpdateSizeWithoutDimension({ containerElement, options, kpis }) {
+    if (!containerElement || ! options || !kpis) {
+      return false;
+    }
     const containerElementSize = containerElement.getBoundingClientRect();
     let elementClientWidth = containerElementSize.width;
     let elementClientHeight = containerElementSize.height;

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -134,7 +134,7 @@ class StatisticBlock extends Component {
     let elementClientHeight = containerSize.height;
     let childrenElements = containerElement.children;
     let dividedBy = options.divideBy;
-    let dividedByNumber = getDivideByNumber(dividedBy);
+    let dividedByNumber = getDivideByNumber(dividedBy) || 1;
     let childrenHeight = 0;
     let childrenCombinedWidth = 0;
 
@@ -161,11 +161,13 @@ class StatisticBlock extends Component {
         }
         else{
           for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
-            childrenHeight = childrenHeight + childrenElements[i].getBoundingClientRect().height;
+            const plusHeight = childrenElements[i] ? childrenElements[i].getBoundingClientRect().height : 0;
+            childrenHeight = childrenHeight + plusHeight;
           }
         }
         for ( let i = 0 ; i < dividedByNumber ; i++){
-          childrenCombinedWidth = childrenCombinedWidth + childrenElements[i].getBoundingClientRect().width;
+          const plusWidth = childrenElements[i] ? childrenElements[i].getBoundingClientRect().width : 0;
+          childrenCombinedWidth = childrenCombinedWidth + plusWidth;
         }
       }
     }
@@ -180,25 +182,28 @@ class StatisticBlock extends Component {
     const containerElementSize = containerElement.getBoundingClientRect();
     let elementClientWidth = containerElementSize.width;
     let elementClientHeight = containerElementSize.height;
-    let childrenElm = containerElement.children;
+    let childrenElements = containerElement.children;
     let childrenCombinedWidth = 0;
     let childrenHeight = 0;
     let dividedBy = options.divideBy;
-    let dividedByNumber = getDivideByNumber(dividedBy);
+    let dividedByNumber = getDivideByNumber(dividedBy) || 1;
     let rows = kpis.qMeasureInfo.length;
     let ratio = Math.floor(rows / dividedByNumber) + 1;
     if (rows % dividedByNumber == 0){
       for (let i = 0 ; i < rows/dividedByNumber ; i++ + ratio){
-        childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
+        const plusHeight = childrenElements[i] ? childrenElements[i].getBoundingClientRect().height : 0;
+        childrenHeight = childrenHeight + plusHeight;
       }
     }
     else{
       for (let i = 0 ; i <= Math.floor(rows/dividedByNumber) ; i++ + ratio){
-        childrenHeight = childrenHeight + childrenElm[i].getBoundingClientRect().height;
+        const plusHeight = childrenElements[i] ? childrenElements[i].getBoundingClientRect().height : 0;
+        childrenHeight = childrenHeight + plusHeight;
       }
     }
     for ( let i = 0 ; i < dividedByNumber ; i++){
-      childrenCombinedWidth = childrenCombinedWidth + childrenElm[i].getBoundingClientRect().width;
+      const plusWidth = childrenElements[i] ? childrenElements[i].getBoundingClientRect().width : 0;
+      childrenCombinedWidth = childrenCombinedWidth + plusWidth;
     }
 
     return elementClientWidth < childrenCombinedWidth || elementClientHeight < childrenHeight;

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -104,17 +104,17 @@ class StatisticBlock extends Component {
       if (this.state.overflow !== "auto" && shouldShowScrollBar) {
         this.setState({ overflow: "auto" });
       }
-
       return;
     }
 
     let currentSize = this.state.size;
+    const thereAreDimensions = this.props.kpis.qDimensionInfo.length > 0;
     const updateSizeArguments = {
-      containerElement: this.refs.parent,
+      containerElement: thereAreDimensions ? this.refs.parent : this.refs.statistics,
       options: this.props.options,
       kpis: this.props.kpis
     };
-    if (this.props.kpis.qDimensionInfo.length > 0) {
+    if (thereAreDimensions) {
       if (this.getIfWeShouldUpdateSize(updateSizeArguments)){
         this.decreaseSize(currentSize);
       }


### PR DESCRIPTION
Fixed the case when there are no dimensions.
To verify:
1. Create a Multi KPI without dimensions
2. Make sure that there are no console errors on page load

Seems to include the fix for: https://tretton37.atlassian.net/browse/QPE-542 as well
Where the cards in card mode were too wide:
![capture](https://user-images.githubusercontent.com/2794781/51498644-978fec80-1dc7-11e9-9be1-3a597f4f5788.PNG)
