### PR TITLE
Option to link to bookmark

### DIFF
--- a/contributors/erikwett.md
+++ b/contributors/erikwett.md
@@ -1,0 +1,11 @@
+2019-06-25
+
+By introducing this file I hereby agree to the terms of the Qlik R&D Contributors License
+Agreement, version 1.0, with MD5 checksum: e4ed5b420a8c9400390a55ac12dad65b.
+
+I furthermore declare that I am authorized and able to make this agreement.
+
+Signed,
+
+Erik Wetterberg
+https://github.com/erikwett

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "homepage": "https://github.com/alner/qsSimpleKPI",
   "bugs": "https://github.com/alner/qsSimpleKPI/issues",
   "author": "Alexander Nerush <ale.nerush@gmail.com>",
+  "contributors": [
+    {
+      "name": "Erik Wetterberg",
+      "email": "erik@upper88.com",
+      "url": "https://upper88.com"
+    }
+  ],
   "license": "MIT",
   "repository": "https://github.com/alner/qsSimpleKPI",
   "scripts": {

--- a/src/component.js
+++ b/src/component.js
@@ -51,7 +51,7 @@ define(dependencies,
       global.React = React;
 
     let initialProperties = require('./initialProperties');
-    let definition = require('./definition')({ ShowService });
+    let definition = require('./definition')({ qlik, ShowService });
     let { paint, beforeDestroy } = require('./paint')({ qlik, DragDropService, LoadedPromise });
 
     return {

--- a/src/definition.js
+++ b/src/definition.js
@@ -16,10 +16,21 @@ import {
 import { FULL_ICONS_SET } from './iconsDefinitions';
 import ATTRIBUTES from './definitionAttributes';
 
-export default function ({ ShowService }) {
+export default function ({ qlik, ShowService }) {
 // let Dialog = options.Dialog;
   //let ShowService = options.ShowService;
-
+  //property panel breaks if options array is empty
+  const EMPTY_BOOKMARKLIST = [{ value: '', label:'No bookmarks' }];
+  let bookmarklist = EMPTY_BOOKMARKLIST;
+  qlik.currApp().getList('BookmarkList', function (reply) {
+    bookmarklist = reply.qBookmarkList.qItems.length < 1
+      ? EMPTY_BOOKMARKLIST : reply.qBookmarkList.qItems.map(function (bm) {
+        return {
+          value: bm.qInfo.qId,
+          label: bm.qMeta.title
+        };
+      });
+  });
   let data= {
     uses: "data",
     items:{
@@ -86,6 +97,39 @@ export default function ({ ShowService }) {
                 component : 'sheet-dropdown',
                 show : function (data) {
                   return data.qDef.useLink;
+                }
+              }
+            }
+          },
+          linkToBookmark: {
+            type: "items",
+            items: {
+              useBookmark: {
+                ref: "qDef.useBookmark",
+                type: "boolean",
+                component: "switch",
+                label: "Link to Bookmark",
+                defaultValue: false,
+                options: [{
+                  value: true,
+                  translation: "properties.on"
+                }, {
+                  value: false,
+                  translation: "properties.off"
+                }],
+                show: function () {
+                  return bookmarklist !== EMPTY_BOOKMARKLIST;
+                }
+              },
+              bookmark: {
+                ref: "qDef.bookmark",
+                type: "string",
+                component: 'dropdown',
+                options: function () {
+                  return bookmarklist;
+                },
+                show: function (data) {
+                  return data.qDef.useBookmark && bookmarklist !== EMPTY_BOOKMARKLIST;
                 }
               }
             }

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import InlineCSS from 'react-inline-css';
-import { DIVIDE_BY, SIZE_OPTIONS, DEFAULT_SIZE, FONT_SIZE_OPTIONS, getSizeIndex  } from './options';
+import { DIVIDE_BY, SIZE_OPTIONS, DEFAULT_SIZE, FONT_SIZE_OPTIONS, getSizeIndex } from './options';
 import DimensionEntry from './dimensionEntry.container';
 import StatisticItem from './statisticItem';
 import ATTRIBUTES from './definitionAttributes';
@@ -145,6 +145,8 @@ class StatisticBlock extends Component {
         fontStyles: {},
         kpiLink: item.kpiLink,
         useLink: item.useLink,
+        useBookmark: item.useBookmark,
+        bookmark: item.bookmark,
         textAlignment: item.textAlignment,
         infographic: item.infographic,
         embeddedItem: item.embeddedItem,
@@ -336,7 +338,10 @@ class StatisticBlock extends Component {
     const services = this.props.services;
     const isAllowOpenSheet = (this.props.services.State
       && !this.props.services.State.isInEditMode());
-    if(kpi.useLink && isAllowOpenSheet /*&& services.Routing*/) {
+    if (kpi.useBookmark && kpi.bookmark && isAllowOpenSheet /*&& services.Routing*/ ) {
+      services.Qlik.currApp().bookmark.apply(kpi.bookmark);
+    }
+    if (kpi.useLink && isAllowOpenSheet /*&& services.Routing*/ ) {
       let linkId;
       if (typeof(kpi.kpiLink) === "string")
         linkId = kpi.kpiLink;


### PR DESCRIPTION
This PR adds the option to link a bookmark to a KPI, meaning that a bookmark will be applied when the user clicks on a KPI and selections made. Can be used separately or combined with sheet navigation.