### PR TITLE
fix: conditional color switch show/hide

### DIFF
--- a/src/definition.js
+++ b/src/definition.js
@@ -59,7 +59,10 @@ export default function ({ ShowService }) {
                 value: false,
                 label: 'Off'
               }
-            ]
+            ],
+            show: function (a) {
+              return a.qLibraryId
+            }
           },
           itemColor: {
             type: "object",


### PR DESCRIPTION
Conditional coloring switch to appear only if measures are master item