### PR TITLE
Fix: QB-675-Label-doesnt-show-after-making-selection-in-MultiKPI

### DIFF
--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -353,7 +353,13 @@ class StatisticBlock extends Component {
             <div className={`ui ${dimensionsOrientation} ${dimShowAsContainer} ${EditModeClass}`} ref="parent" style={segmentsStyle}>
               {
                 kpis.qDataPages[0].qMatrix.map(function(dim, dindex){
-                  const dimensionLabel = dim[dimNo].qText;
+                  let dimensionLabel = dim[dimNo].qText;
+                  if (typeof(dimensionLabel) === 'undefined' || dimensionLabel === '')
+                  {
+                    dimensionLabel = '-';
+                  }
+                  //keyValue added to keep the key value unique
+                  let keyValue = Math.floor(Math.random() * 100000);
                   const dimensionIndex = dim[dimNo].qElemNumber;
                   let measures = self.renderKpis(kpis, dindex, divideByNumber);
                   let aMeasureHasInfographicIcons = false;
@@ -377,7 +383,7 @@ class StatisticBlock extends Component {
                   };
                   return (
                     <DimensionEntry
-                      key={dimensionLabel}
+                      key={keyValue}
                       dimension={dim}
                       isInEditMode={isInEditMode}
                       inStoryMode={inStoryMode}


### PR DESCRIPTION
**Bug:** 
QB-675 (https://jira.qlikdev.com/browse/QB-675)

**Issue:**
Label doesn't show after making a selection in Multi KPI extension

**Fix:**
Now the value label will be displayed after making a selection in Multi KPI extension

**Files updated:**
staticBlock.js  file got updated with the keyValue to some random and unique number
let keyValue = Math.floor(Math.random() * 100000);