### PR TITLE
Qb 491 line alignment

### DIFF
--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -377,7 +377,7 @@ class StatisticBlock extends Component {
                   };
                   return (
                     <DimensionEntry
-                      key={dimensionLabel}
+                      key={dindex}
                       dimension={dim}
                       isInEditMode={isInEditMode}
                       inStoryMode={inStoryMode}

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -353,7 +353,11 @@ class StatisticBlock extends Component {
             <div className={`ui ${dimensionsOrientation} ${dimShowAsContainer} ${EditModeClass}`} ref="parent" style={segmentsStyle}>
               {
                 kpis.qDataPages[0].qMatrix.map(function(dim, dindex){
-                  const dimensionLabel = dim[dimNo].qText;
+                  let dimensionLabel = dim[dimNo].qText;
+                  if (typeof(dimensionLabel) === 'undefined' || dimensionLabel === '')
+                  {
+                    dimensionLabel = '-';
+                  }
                   const dimensionIndex = dim[dimNo].qElemNumber;
                   let measures = self.renderKpis(kpis, dindex, divideByNumber);
                   let aMeasureHasInfographicIcons = false;


### PR DESCRIPTION
**Bug:**
QB-491 (https://jira.qlikdev.com/browse/QB-491)

**Issue:**
In some cases the dimension with Null or blank dimensional value does not align text label properly(the horizontal line was not aligned properly if '-' was missing in place of empty value).
![image-2019-11-18-15-07-58-493](https://user-images.githubusercontent.com/55872315/71621789-65058b00-2bf7-11ea-96e2-9b1315d0285d.png)

**Fix:**
Will be checking for empty values in variable 'dimensionLabel' and assign  '-'
file-statisticBlock.js line number 357


