### PR TITLE
fix(qb-751): charts are not appearing properly in mobile browsers

### DIFF
--- a/semantic/src/definitions/views/card.less
+++ b/semantic/src/definitions/views/card.less
@@ -1063,7 +1063,6 @@ a.ui.card:hover,
     height: auto !important;
     margin: @stackableRowSpacing @stackableCardSpacing;
     padding: 0 !important;
-    //width: @stackableMargin !important;
     width: 50%;
   }
 }

--- a/semantic/src/definitions/views/card.less
+++ b/semantic/src/definitions/views/card.less
@@ -1064,6 +1064,7 @@ a.ui.card:hover,
     margin: @stackableRowSpacing @stackableCardSpacing;
     padding: 0 !important;
     width: @stackableMargin !important;
+    //bug751
   }
 }
 

--- a/semantic/src/definitions/views/card.less
+++ b/semantic/src/definitions/views/card.less
@@ -1063,8 +1063,8 @@ a.ui.card:hover,
     height: auto !important;
     margin: @stackableRowSpacing @stackableCardSpacing;
     padding: 0 !important;
-    width: @stackableMargin !important;
-    //bug751
+    //width: @stackableMargin !important;
+    width: 50%;
   }
 }
 


### PR DESCRIPTION
In Multi KPI chart when the Dimension selected to |Show as [Cards] the chart content where not properly aligned when viewed in mobile browser as shown below image

<img width="224" alt="751-2" src="https://user-images.githubusercontent.com/55872315/74814757-fe127180-531d-11ea-8050-60c4ca3b5b38.png">
We updated the css width to fix it as shown in below image
<img width="224" alt="bug-751" src="https://user-images.githubusercontent.com/55872315/74814772-05d21600-531e-11ea-8fb5-b0a308dee1c2.png">
