### PR TITLE
fix: handle when qNumFormat is null

### DIFF
--- a/src/definition.js
+++ b/src/definition.js
@@ -33,7 +33,7 @@ export default function ({ ShowService }) {
             ref: "qDef.autoFormatTemplate",
             defaultValue: "0A",
             show: function(a) {
-              return a.qDef.qNumFormat.qType === "U";
+              return a.qDef.qNumFormat && a.qDef.qNumFormat.qType === "U";
             }
           },
           labelColor: {


### PR DESCRIPTION
when the master measure formatting feature is in sense.
It may cause qNumFormat to be null so handle that case