### PR TITLE
fix: using a proper react element key instead of randomized

### DIFF
--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -358,8 +358,6 @@ class StatisticBlock extends Component {
                   {
                     dimensionLabel = '-';
                   }
-                  //keyValue added to keep the key value unique
-                  let keyValue = Math.floor(Math.random() * 100000);
                   const dimensionIndex = dim[dimNo].qElemNumber;
                   let measures = self.renderKpis(kpis, dindex, divideByNumber);
                   let aMeasureHasInfographicIcons = false;
@@ -383,7 +381,7 @@ class StatisticBlock extends Component {
                   };
                   return (
                     <DimensionEntry
-                      key={keyValue}
+                      key={dimensionIndex}
                       dimension={dim}
                       isInEditMode={isInEditMode}
                       inStoryMode={inStoryMode}


### PR DESCRIPTION
The key for the DimensionEntry element was randomized, causing the component to re-render. It was a degrade from #84. This is avoided by using a proper key.

Fixes blinking issue: https://jira.qlikdev.com/browse/QB-1740