### PR TITLE
fix: printing issue QB-1858

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -102,13 +102,6 @@ export default function setupPaint({
             );
           } catch (error) {
             console.log(error);
-          }
-          finally{
-            // Sense's undo/redo function waits for this promise to resolve,
-            // if it doesn't resolve, you cannot undo.
-            // There does not seem to be a reason for the code above to be inside a promise,
-            // and it does not always resolve after repainting.
-            // Therefore, we have resorted to the cowboy hack below. Enjoy!
             resolve();
           }
         })

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -25,10 +25,8 @@ class StatisticBlock extends Component {
   componentDidMount(){
     var self = this;
 
-    // 3.2 SR2 Printing service patch (timeout strange behaviour, 10 equals to 10 sec (instead of 10 msec) in setTimeout)
-    const isPrinting = this.isPrinting();
-    const checkRequiredSizeDelay = isPrinting ? 1 : 50; //1
-    const readyDelay = isPrinting ? 10 : 10000; // 10
+    const checkRequiredSizeDelay = 1;
+    const readyDelay = 10;
 
     this.handleIdCheckResize = setTimeout(function(){self.checkRequiredSize();}, checkRequiredSizeDelay);
     // initial resize should not be visible
@@ -51,12 +49,6 @@ class StatisticBlock extends Component {
     // initial resize should not be visible
     this.setState({ is_show: true });
     this.props.services.PrintResolver && this.props.services.PrintResolver(); // we are ready... can be printed!
-  }
-
-  isPrinting() {
-    return this.props.services.QlikComponent.backendApi.isSnapshot
-      && this.props.services.Qlik.navigation
-      && !this.props.services.Qlik.navigation.inClient;
   }
 
   restoreSize(props){

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -6,6 +6,9 @@ import DimensionEntry from './dimensionEntry.container';
 import StatisticItem from './statisticItem';
 import ATTRIBUTES from './definitionAttributes';
 
+const checkRequiredSizeDelay = 1;
+const readyDelay = 10;
+
 class StatisticBlock extends Component {
   constructor(props){
     super(props);
@@ -24,10 +27,6 @@ class StatisticBlock extends Component {
 
   componentDidMount(){
     var self = this;
-
-    const checkRequiredSizeDelay = 1;
-    const readyDelay = 10;
-
     this.handleIdCheckResize = setTimeout(function(){self.checkRequiredSize();}, checkRequiredSizeDelay);
     // initial resize should not be visible
     this.handleIdComponentReady = setTimeout(function(){ self.componentReady(); }, readyDelay);
@@ -35,10 +34,15 @@ class StatisticBlock extends Component {
   componentWillUnmount(){
     clearTimeout(this.handleIdComponentReady);
     clearTimeout(this.handleIdCheckResize);
+    clearTimeout(this.handleIdResolveUpdatePromise);
   }
 
   componentDidUpdate() {
+    var self = this;
     this.checkRequiredSize();
+    // Resolve promise for undo/redo to work (QB-1858)
+    // Use same delay in componentReady so it doesn't resolve to early
+    this.handleIdResolveUpdatePromise = setTimeout(function(){ self.resolveUpdatePromise(); }, readyDelay);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -48,7 +52,11 @@ class StatisticBlock extends Component {
   componentReady() {
     // initial resize should not be visible
     this.setState({ is_show: true });
-    this.props.services.PrintResolver && this.props.services.PrintResolver(); // we are ready... can be printed!
+    this.props.services.PrintResolver && this.props.services.PrintResolver();
+  }
+
+  resolveUpdatePromise(){
+    this.props.services.PrintResolver && this.props.services.PrintResolver();
   }
 
   restoreSize(props){


### PR DESCRIPTION
This fixes issues with printing. I have removed a promise resolve() in the paint function that always resolved directly. This caused problems in printing (download) because the promise resolved too early. However, the resolve function is passed as `PrintResolver` to statisticBlock.js where it is later resolved in `componentReady()` now.  This is now where it resolves correctly. 
After some manual testing I found that undo/redo relies on the promise to be resolved every time the is updated as well. So I made sure it also resolves in `componentDidUpdate` in statisticBlock.js

Fixes issue: https://jira.qlikdev.com/browse/QB-1858