### PR TITLE
fix: revert "fix: calculations not updating"

### DIFF
--- a/src/ValueComponent.js
+++ b/src/ValueComponent.js
@@ -120,11 +120,6 @@ let DragDropSpec = {
       ReactDOM.render(<span>{this.props.children}</span>, placeElement);
       this.setState({ itemid: null, object: null, isObjectInjected: false });
     }
-    if(!this.props.embeddedItem){
-      $(placeElement).empty();
-      $(placeElement).height('auto');
-      ReactDOM.render(<span>{this.props.children}</span>, placeElement);
-    }
   }
 };
 


### PR DESCRIPTION
reverting [this](https://github.com/qlik-oss/qsSimpleKPI/commit/ed722d50eed1c140a602d31ce85393c8888d51e1)

React is not a fan of `$(placeElement).empty();` since it looses track of the original element. The whole thing of removing and then adding a new element is really weird and should not be done for embedded objects either. Will reopen the bug in jira