### PR TITLE
fix: avoid render react items for embedded viz

### DIFF
--- a/src/ValueComponent.js
+++ b/src/ValueComponent.js
@@ -4,11 +4,11 @@ import senseDragDropSupport from './senseDragDropSupport';
 
 class ValueComponent extends Component {
   render(){
-    let { valueStyles } = this.props;
-
+    let { valueStyles } = this.props;    
+    
     return (
       <div title={this.props.children[1].props.children} className="value" style={valueStyles}>
-        {this.props.children}
+        { (this.props.embeddedItem) ? null : this.props.children }
       </div>
     );
   }

--- a/src/ValueComponent.js
+++ b/src/ValueComponent.js
@@ -4,8 +4,8 @@ import senseDragDropSupport from './senseDragDropSupport';
 
 class ValueComponent extends Component {
   render(){
-    let { valueStyles } = this.props;    
-    
+    let { valueStyles } = this.props;
+
     return (
       <div title={this.props.children[1].props.children} className="value" style={valueStyles}>
         { (this.props.embeddedItem) ? null : this.props.children }


### PR DESCRIPTION
This fixes a problem with  Multi KPI extension not updating calculations. Happens when there is two measures and an embedded viz and then making selections. See https://jira.qlikdev.com/browse/QB-2258 

I found out that the problem was caused by React trying to keep track of the child elements rendered in ValueComponent.render(). But when a viz is embedded these are gone and an error is thrown in React. So the fix is to not render any child value items if there is an embedded viz. They are not needed anyway.
		