### PR TITLE
fix: deprecated refs

### DIFF
--- a/src/dimensionEntry.js
+++ b/src/dimensionEntry.js
@@ -16,7 +16,10 @@ class DimensionEntry extends Component {
     this.handleClick = this.handleClick.bind(this);
     this.hidePointerCursor = this.hidePointerCursor.bind(this);
     this.getlabelWidth = this.getlabelWidth.bind(this);
-
+    this.chartBody = null;
+    this.chartBodyRef = element => {
+      this.chartBody = element;
+    };
   }
 
   hidePointerCursor () {
@@ -27,11 +30,13 @@ class DimensionEntry extends Component {
       return "default";
     }
   }
-  getlabelWidth(){
-    var chartBody = this.refs.chartBody;
-    var chartBodywidth = chartBody && chartBody.getBoundingClientRect().width;
-    return chartBodywidth;
 
+  getlabelWidth(){
+    // QB-4486
+    // Multi KPI labels are distracted after select and clear selection
+    const chartBody = this.chartBody;
+    var chartBodywidth = chartBody && chartBody.width;
+    return chartBodywidth;
   }
   updateFlexBasis (key) {
     this.props.style.flexBasis = dividedByObject[key];
@@ -90,7 +95,7 @@ class DimensionEntry extends Component {
             >{label.text}</a>
           )
         }
-        <div className={`ui ${divideBy} ${label.alignment} statistics`} ref='chartBody'>
+        <div className={`ui ${divideBy} ${label.alignment} statistics`} ref={this.chartBodyRef}>
           {children}
         </div>
       </div>

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -344,7 +344,6 @@
       padding: 0;
       a {
         font-size: 16px;
-        min-width: 250px;
         // labels sizing
         &.mini {
           font-size: xx-small;


### PR DESCRIPTION
Info:
(property) React.Component<any, any, any>.refs: {
    [key: string]: React.ReactInstance;
}
@deprecated — https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
'refs' is deprecated.ts(6385)
index.d.ts(497, 12): The declaration was marked as deprecated here

Previous:
<img width="302" alt="Screenshot 2021-03-24 at 15 33 28" src="https://user-images.githubusercontent.com/4471489/112354425-f6fe2580-8ccc-11eb-9910-11f38068299c.png">

<img width="1187" alt="Screenshot 2021-03-24 at 15 36 18" src="https://user-images.githubusercontent.com/4471489/112354448-fcf40680-8ccc-11eb-889c-d4753c6aa825.png">

<img width="662" alt="Screenshot 2021-03-24 at 15 36 34" src="https://user-images.githubusercontent.com/4471489/112354479-05e4d800-8ccd-11eb-9569-e29d43206e2a.png">

Now:
<img width="258" alt="Screenshot 2021-03-24 at 18 16 46" src="https://user-images.githubusercontent.com/4471489/112354624-29a81e00-8ccd-11eb-8d08-082b4a3233a4.png">

<img width="1183" alt="Screenshot 2021-03-24 at 18 16 51" src="https://user-images.githubusercontent.com/4471489/112354674-36c50d00-8ccd-11eb-895e-453f7982b628.png">

