### PR TITLE
fix: correct css for scrolling and vertical positioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ BUMPED_VERSION
 *.map
 *.log
 yarn.lock
+.DS_Store

--- a/src/qlik-multi-kpi.less
+++ b/src/qlik-multi-kpi.less
@@ -38,21 +38,18 @@
   .top-aligned-items {
     height: 100%;
     display: flex;
-    align-items: flex-start;
     overflow: auto;
   }
 
   .bottom-aligned-items {
     height: 100%;
     display: flex;
-    align-items: flex-end;
     overflow: auto;
   }
 
   .center-aligned-items {
     height: 100%;
     display: flex;
-    align-items: center;
     overflow: auto;
   }
 

--- a/src/statisticBlock.js
+++ b/src/statisticBlock.js
@@ -407,9 +407,13 @@ class StatisticBlock extends Component {
           </div>
         );
       } else {
+        const style = {
+          marginTop: verticalAlign === 'top-aligned-items' || verticalAlign === 'stretched-items' ? 0 : 'auto',
+          marginBottom: verticalAlign === 'bottom-aligned-items' || verticalAlign === 'stretched-items' ? 0 : 'auto',
+        };
         items = (
           <div className={`${verticalAlign}`}>
-            <div ref="statistics" className={`ui ${divideBy} statistics`}>
+            <div ref="statistics" className={`ui ${divideBy} statistics`} style={style}>
               {self.renderKpis(kpis, 0, divideByNumber)}
             </div>
           </div>);


### PR DESCRIPTION
align-items does not work properly when the content overflows, so fixing the centering using margin auto/0 instead. This should probably be done with classes instead for consistency but I find this easier.

scrolling when overflowing:
![Kapture 2024-06-07 at 12 34 57](https://github.com/qlik-oss/qsSimpleKPI/assets/9249820/c056035a-c7b5-483f-a2bb-2eff056e057a)

Positioning when not overflowing:
![Kapture 2024-06-07 at 12 35 44](https://github.com/qlik-oss/qsSimpleKPI/assets/9249820/70a6bcc8-a4a5-4378-aa6a-90d6a89e87c8)
